### PR TITLE
fix bug

### DIFF
--- a/vnpy_optionmaster/ui/widget.py
+++ b/vnpy_optionmaster/ui/widget.py
@@ -177,7 +177,7 @@ class OptionManager(QtWidgets.QWidget):
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
         """"""
-        if self.market_monitor:
+        if hasattr(self,'market_monitor') and self.market_monitor:
             self.market_monitor.close()
             self.greeks_monitor.close()
             self.volatility_chart.close()


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 用vnpy的源码导入vnpy_optionmaster模块中发现一个bug，就是在关闭页面的时候抛出异常如下图所示
<img width="589" height="588" alt="image" src="https://github.com/user-attachments/assets/2aee141a-96ea-4150-85ec-d78005cc0159" />

2.这个是由于如果market_montior属性不存在为空的话，直接会抛出异常，所以需要加个判空的条件

## 相关的Issue号（如有）

Close #