### PR TITLE
Fix f-string syntax error with nested quotes in widget.py

### DIFF
--- a/vnpy_optionmaster/ui/widget.py
+++ b/vnpy_optionmaster/ui/widget.py
@@ -799,8 +799,8 @@ class OptionRiskWidget(QtWidgets.QWidget):
         self.net_pos_label.setText(str(data["net_pos"]))
         self.order_count_label.setText(str(data["order_count"]))
         self.cancel_count_label.setText(str(data["cancel_count"]))
-        self.trade_position_ratio_label.setText(f"{data["trade_position_ratio"]:.2f}")
-        self.cancel_order_ratio_label.setText(f"{data["cancel_order_ratio"]:.2f}")
+        self.trade_position_ratio_label.setText(f"{data['trade_position_ratio']:.2f}")
+        self.cancel_order_ratio_label.setText(f"{data['cancel_order_ratio']:.2f}")
 
         texts: list = []
         if data["trade_position_ratio"] >= self.trade_position_limit:


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

直接运行会报错：


```
self.trade_position_ratio_label.setText(f"{data["trade_position_ratio"]:.2f}")
                                                     ^^^^^^^^^^^^^^^^^^^^
SyntaxError: f-string: unmatched '['
```

解决方式为将内部双引号改为单引号即可。

## 相关的Issue号（如有）

Close #